### PR TITLE
Refactor cmake target names to conventional

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_executable(roboteam_interface main.cpp)
 
 target_link_libraries(roboteam_interface
-        PRIVATE interface_lib
-        PRIVATE interface_utils_lib)
+        PRIVATE roboteam_interface_lib
+        PRIVATE roboteam_interface_utils_lib)
 
 target_compile_options(roboteam_interface PRIVATE "${COMPILER_FLAGS}")

--- a/libs/interface/CMakeLists.txt
+++ b/libs/interface/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_AUTORCC OFF)
 set(CMAKE_AUTOUIC OFF)
 set(CMAKE_INCLUDE_CURRENT_DIR OFF) #Find includes in corresponding build directories
 
-add_library(interface_lib
+add_library(roboteam_interface_lib
         src/InterfaceFieldScene.cpp
         src/InterfaceFieldRenderer.cpp
         src/MainWindow.cpp
@@ -39,12 +39,12 @@ add_library(interface_lib
         include/InterfaceWidgetDebugDisplay.h
         )
 
-target_link_libraries(interface_lib
+target_link_libraries(roboteam_interface_lib
         PUBLIC Qt::Widgets
-        PUBLIC interface_utils_lib)
+        PUBLIC roboteam_interface_utils_lib)
 
-target_include_directories(interface_lib
+target_include_directories(roboteam_interface_lib
         PUBLIC include/)
 
 
-target_compile_options(interface_lib PRIVATE "${COMPILER_FLAGS}")
+target_compile_options(roboteam_interface_lib PRIVATE "${COMPILER_FLAGS}")

--- a/libs/interface_utils/CMakeLists.txt
+++ b/libs/interface_utils/CMakeLists.txt
@@ -1,17 +1,17 @@
-add_library(interface_utils_lib
+add_library(roboteam_interface_utils_lib
         src/InterfaceDeclaration.cpp
         src/InterfaceDeclarations.cpp
         src/InterfaceSettings.cpp
         src/InterfaceValue.cpp)
 
-target_include_directories(interface_utils_lib
+target_include_directories(roboteam_interface_utils_lib
         PRIVATE include/roboteam_interface_utils
         INTERFACE include/
         )
 
-target_link_libraries(interface_utils_lib
+target_link_libraries(roboteam_interface_utils_lib
         PUBLIC roboteam_networking
         PUBLIC nlohmann_json::nlohmann_json
         PUBLIC roboteam_utils)
 
-target_compile_options(interface_utils_lib PRIVATE "${COMPILER_FLAGS}")
+target_compile_options(roboteam_interface_utils_lib PRIVATE "${COMPILER_FLAGS}")


### PR DESCRIPTION
This PR renames the CMake targets by prepending roboteam in order to follow the naming convention