### PR TITLE
Fix/qt and operators

### DIFF
--- a/libs/interface/CMakeLists.txt
+++ b/libs/interface/CMakeLists.txt
@@ -40,7 +40,7 @@ add_library(roboteam_interface_lib
         )
 
 target_link_libraries(roboteam_interface_lib
-        PUBLIC Qt::Widgets
+        PUBLIC Qt5::Widgets
         PUBLIC roboteam_interface_utils_lib)
 
 target_include_directories(roboteam_interface_lib

--- a/libs/interface_utils/include/roboteam_interface_utils/InterfaceDeclaration.h
+++ b/libs/interface_utils/include/roboteam_interface_utils/InterfaceDeclaration.h
@@ -161,6 +161,9 @@ struct InterfaceDeclaration {
         lhs.isMutable == this->isMutable &&
         lhs.options == this->options;
     }
+    bool operator!=(const InterfaceDeclaration& lhs) const {
+        return !(this->operator==(lhs));
+    }
 };
 
 void from_json(const nlohmann::json& json, InterfaceDeclaration& declaration);

--- a/libs/interface_utils/include/roboteam_interface_utils/InterfaceValue.h
+++ b/libs/interface_utils/include/roboteam_interface_utils/InterfaceValue.h
@@ -30,6 +30,9 @@ struct InterfaceValue {
     bool operator==(const InterfaceValue& lhs) const {
         return lhs.variant == this->variant;
     }
+    bool operator!=(const InterfaceValue& lhs) const {
+        return !(this->operator==(lhs));
+    }
 };
 void from_json(const nlohmann::json& j, InterfaceValue& p);
 void to_json(nlohmann::json& j, const InterfaceValue& p);

--- a/libs/interface_utils/src/InterfaceValue.cpp
+++ b/libs/interface_utils/src/InterfaceValue.cpp
@@ -64,7 +64,7 @@ void to_json(nlohmann::json& j, const InterfaceValue& p) {
 
 void from_json(const nlohmann::json& j, InterfaceValue& p) {
     if (j.contains("int")) {
-        p.variant = j.at("int").get<int>();
+        p.variant = static_cast<int64_t>(j.at("int").get<int>());
     } else if (j.contains("bool")) {
         p.variant = j.at("bool").get<bool>();
     } else if (j.contains("float")) {


### PR DESCRIPTION
This PR changes the way we link Qt with our interface code, and adds operator overloads that were currently still missing (specifically the `operator!=` function). This also casts the read json integer value to an int64_t type