### PR TITLE
Basic interface layout

### DIFF
--- a/apps/main.cpp
+++ b/apps/main.cpp
@@ -16,6 +16,9 @@
 #include <QScrollArea>
 #include <InterfaceSyncedCheckableButton.h>
 #include "InterfaceWidgetDebugDisplay.h"
+#include "InterfaceSyncedDropdown.h"
+#include <QTabWidget>
+#include <InterfaceSyncedText.h>
 
 
 int main(int argc, char *argv[]) {
@@ -51,6 +54,13 @@ int main(int argc, char *argv[]) {
     scroll->setWidgetResizable(true);
     scroll->setWidget(new rtt::Interface::InterfaceWidgetRobotOverview(ctrl));
 
+    auto play_selector = new rtt::Interface::InterfaceSyncedDropdown(ctrl, "PLAY_SELECTOR");
+    auto game_state_selector = new rtt::Interface::InterfaceSyncedDropdown(ctrl, "GAME_STATE_SELECTOR");
+
+    auto dropdown_layout = new QVBoxLayout;
+    dropdown_layout->addWidget(play_selector);
+    dropdown_layout->addWidget(game_state_selector);
+
     auto team_button = new rtt::Interface::InterfaceSyncedCheckableButton(ctrl, "IS_YELLOW");
     team_button->setText("Is Yellow");
     auto invariants_button = new rtt::Interface::InterfaceSyncedCheckableButton(ctrl, "IGNORE_INVARIANTS");
@@ -58,25 +68,57 @@ int main(int argc, char *argv[]) {
     auto right_button = new rtt::Interface::InterfaceSyncedCheckableButton(ctrl, "IS_RIGHT");
     right_button->setText("Play Right");
     auto ctrlLaytout = new QVBoxLayout;
-    ctrlLaytout->setAlignment(Qt::AlignRight);
+    ctrlLaytout->setAlignment(Qt::AlignCenter);
 
     ctrlLaytout->addWidget(team_button);
     ctrlLaytout->addWidget(right_button);
     ctrlLaytout->addWidget(invariants_button);
 
+    auto bottom_left_layout = new QHBoxLayout;
+    bottom_left_layout->addLayout(dropdown_layout, 2);
+    bottom_left_layout->addLayout(ctrlLaytout, 2);
+    bottom_left_layout->addWidget(new rtt::Interface::InterfaceWidgetStopButton(ctrl), 4);
 
-
-//    auto debug = new rtt::Interface::InterfaceWidgetDebugDisplay(&window, ctrl);
-//    layout.addWidget(debug, 1, 2, 2, 2);
     auto leftLayout = new QVBoxLayout;
     leftLayout->addWidget(fieldWidget, 3);
-    leftLayout->addLayout(ctrlLaytout, 1);
-    leftLayout->addWidget(new rtt::Interface::InterfaceWidgetStopButton(ctrl), 5);
+    leftLayout->addLayout(bottom_left_layout, 1);
+
+
+    auto tabs = new QTabWidget;
+
+    auto sim_settings = new QWidget;
+    auto sim_layout = new QVBoxLayout;
+    auto conn_layout = new QHBoxLayout;
+
+    conn_layout->addWidget(new rtt::Interface::InterfaceSyncedText(ctrl, "SIM_HOST"), 4);
+    auto port_text = new rtt::Interface::InterfaceSyncedText(ctrl, "SIM_PORT");
+    port_text->setValidator(new QIntValidator());
+    conn_layout->addWidget(port_text, 1);
+    sim_layout->addWidget(new rtt::Interface::InterfaceSyncedDropdown(ctrl, "ROBOTHUB_TARGET_SELECTOR"));
+    sim_layout->addLayout(conn_layout);
+    sim_layout->setAlignment(Qt::AlignTop);
+
+
+    sim_settings->setLayout(sim_layout);
+    sim_settings->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
+
+    tabs->addTab(sim_settings, "Robothub");
+
+
+
+    tabs->addTab(new rtt::Interface::InterfaceWidgetDebugDisplay(ctrl), "Debug");
+
+    auto right_layout = new QVBoxLayout;
+    right_layout->addWidget(scroll, 1);
+    right_layout->addWidget(tabs, 2);
+
+
     auto topLayout = new QHBoxLayout;
     topLayout->addLayout(leftLayout, 5);
-    topLayout->addWidget(scroll, 5);
+    topLayout->addLayout(right_layout, 4);
 
     layout.addLayout(topLayout, 0, 0);
+
 
 
     auto intWidget = new QWidget;

--- a/apps/main.cpp
+++ b/apps/main.cpp
@@ -25,35 +25,7 @@ int main(int argc, char *argv[]) {
 
     auto ctrl = std::make_shared<rtt::Interface::InterfaceControllerClient>();
     ctrl->run();
-    ctrl->getValues().lock()->setSetting("IS_YELLOW", false);
-
-    proto::State state;
-
-    for (int i = 0; i < 6; i++) {
-        proto::WorldRobot robot;
-        robot.set_id(i);
-        robot.set_angle(1.0);
-        robot.set_angle(69.0);
-        robot.mutable_pos()->set_x(0.0);
-        robot.mutable_pos()->set_y(0.0);
-
-        robot.mutable_vel()->set_x(0.0);
-        robot.mutable_vel()->set_y(0.0);
-
-        state.mutable_ball_camera_world()->mutable_blue()->Add(std::move(robot));
-    }
-
-
-    ctrl->getFieldState().lock()->setState(state);
-    rtt::Interface::InterfaceDeclaration decl;
-    decl.path = "AAAA_DEBUG";
-    decl.description = "TEST";
-    decl.isMutable = true;
-    decl.defaultValue = 50.0f;
-    decl.options = rtt::Interface::InterfaceSlider("AAA", 0, 100, 1, 1);
-    ctrl->getDeclarations().lock()->addDeclaration(decl);
-
-    ctrl->getValues().lock()->setSetting("AAAA_DEBUG", 50.0f);
+    ctrl->getValues().lock()->setSetting("IS_YELLOW", true);
 
     auto view = new InterfaceFieldView(ctrl->getFieldState());
     view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -63,7 +35,7 @@ int main(int argc, char *argv[]) {
     view->setAlignment(Qt::AlignLeft | Qt::AlignTop);
     auto fieldLayout = new QHBoxLayout;
 
-    fieldLayout->addWidget(view, 3);
+    fieldLayout->addWidget(view, 4);
 
     auto fieldWidget = new QWidget;
     fieldWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -77,13 +49,13 @@ int main(int argc, char *argv[]) {
     QGridLayout layout;
     QScrollArea *scroll = new QScrollArea;
     scroll->setWidgetResizable(true);
-    scroll->setWidget(new rtt::Interface::InterfaceWidgetRobotOverview(&window, ctrl));
+    scroll->setWidget(new rtt::Interface::InterfaceWidgetRobotOverview(ctrl));
 
-    auto team_button = new rtt::Interface::InterfaceSyncedCheckableButton(&window, ctrl, "IS_YELLOW");
+    auto team_button = new rtt::Interface::InterfaceSyncedCheckableButton(ctrl, "IS_YELLOW");
     team_button->setText("Is Yellow");
-    auto invariants_button = new rtt::Interface::InterfaceSyncedCheckableButton(&window, ctrl, "IGNORE_INVARIANTS");
+    auto invariants_button = new rtt::Interface::InterfaceSyncedCheckableButton(ctrl, "IGNORE_INVARIANTS");
     invariants_button->setText("Ignore Invariants");
-    auto right_button = new rtt::Interface::InterfaceSyncedCheckableButton(&window, ctrl, "IS_RIGHT");
+    auto right_button = new rtt::Interface::InterfaceSyncedCheckableButton(ctrl, "IS_RIGHT");
     right_button->setText("Play Right");
     auto ctrlLaytout = new QVBoxLayout;
     ctrlLaytout->setAlignment(Qt::AlignRight);
@@ -92,14 +64,17 @@ int main(int argc, char *argv[]) {
     ctrlLaytout->addWidget(right_button);
     ctrlLaytout->addWidget(invariants_button);
 
+
+
 //    auto debug = new rtt::Interface::InterfaceWidgetDebugDisplay(&window, ctrl);
 //    layout.addWidget(debug, 1, 2, 2, 2);
     auto leftLayout = new QVBoxLayout;
     leftLayout->addWidget(fieldWidget, 3);
     leftLayout->addLayout(ctrlLaytout, 1);
+    leftLayout->addWidget(new rtt::Interface::InterfaceWidgetStopButton(ctrl), 5);
     auto topLayout = new QHBoxLayout;
     topLayout->addLayout(leftLayout, 5);
-    topLayout->addWidget(scroll, 3);
+    topLayout->addWidget(scroll, 5);
 
     layout.addLayout(topLayout, 0, 0);
 
@@ -111,10 +86,6 @@ int main(int argc, char *argv[]) {
     window.setCentralWidget(intWidget);
     window.show();
     window.setWindowTitle("RBTT (Interface)");
-
-    emit window.valuesChanged(ctrl->getValues().lock());
-    emit window.declarationsChanged(ctrl->getDeclarations().lock());
-    emit window.valuesChanged(ctrl->getValues().lock());
 
 
     auto retval = roboteam_interface.exec();

--- a/libs/interface/CMakeLists.txt
+++ b/libs/interface/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(roboteam_interface_lib
         include/InterfaceWidgetRobotDisplay.h
         include/InterfaceSyncedCheckableButton.h
         include/InterfaceWidgetDebugDisplay.h
+        include/InterfaceControllerClient.h
         )
 
 target_link_libraries(roboteam_interface_lib

--- a/libs/interface/include/InterfaceControllerClient.h
+++ b/libs/interface/include/InterfaceControllerClient.h
@@ -22,6 +22,7 @@ namespace rtt::Interface {
             QObject::connect(&interface_timer, &QTimer::timeout, this, &InterfaceControllerClient::refresh_trigger);
             interface_timer.start(16); // 60 FPS
         }
+        void stop() override;
     signals:
         void refresh_trigger();
 

--- a/libs/interface/include/InterfaceControllerClient.h
+++ b/libs/interface/include/InterfaceControllerClient.h
@@ -8,15 +8,26 @@
 
 #include <roboteam_interface_utils/InterfaceController.h>
 #include <WorldNetworker.hpp>
+#include <QObject>
+#include <QTimer>
 
 #include "InterfaceFieldStateStore.h"
 
 namespace rtt::Interface {
-    class InterfaceControllerClient: public InterfaceController<16971, 20, 20, proto::UiValues, proto::ModuleState> {
+    class InterfaceControllerClient: public QObject, public InterfaceController<16971, 20, 20, proto::UiValues, proto::ModuleState>  {
+        Q_OBJECT
     public:
         std::weak_ptr<InterfaceFieldStateStore> getFieldState() const;
-        InterfaceControllerClient(): fieldState(std::make_shared<InterfaceFieldStateStore>()), InterfaceController<16971, 20, 20, proto::UiValues, proto::ModuleState>(), field_subscriber(std::make_unique<rtt::net::WorldSubscriber>([this] (auto state) { field_state_callback(state); })) {}
+        InterfaceControllerClient(): QObject(), fieldState(std::make_shared<InterfaceFieldStateStore>()), InterfaceController<16971, 20, 20, proto::UiValues, proto::ModuleState>(), field_subscriber(std::make_unique<rtt::net::WorldSubscriber>([this] (auto state) { field_state_callback(state); })) {
+            QObject::connect(&interface_timer, &QTimer::timeout, this, &InterfaceControllerClient::refresh_trigger);
+            interface_timer.start(16); // 60 FPS
+        }
+    signals:
+        void refresh_trigger();
+
     private:
+        QTimer interface_timer;
+
         std::unique_ptr<rtt::net::WorldSubscriber> field_subscriber;
 
         std::shared_ptr<InterfaceFieldStateStore> fieldState;

--- a/libs/interface/include/InterfaceSyncedCheckableButton.h
+++ b/libs/interface/include/InterfaceSyncedCheckableButton.h
@@ -13,7 +13,7 @@ namespace rtt::Interface {
     class InterfaceSyncedCheckableButton: public QPushButton {
         Q_OBJECT
     public:
-        InterfaceSyncedCheckableButton(const MainWindow*, std::weak_ptr<InterfaceControllerClient>, std::string, QWidget* = nullptr);
+        InterfaceSyncedCheckableButton(std::weak_ptr<InterfaceControllerClient>, std::string, QWidget* = nullptr);
 
     protected:
         std::string identity;
@@ -21,7 +21,7 @@ namespace rtt::Interface {
 
         std::weak_ptr<InterfaceControllerClient> ctrl;
     public slots:
-        void updateValue(std::weak_ptr<InterfaceSettings>);
+        void updateValue();
     private slots:
         void didCheck(bool);
     };

--- a/libs/interface/include/InterfaceSyncedCheckbox.h
+++ b/libs/interface/include/InterfaceSyncedCheckbox.h
@@ -14,15 +14,15 @@ namespace rtt::Interface {
     class InterfaceSyncedCheckbox: public QCheckBox {
         Q_OBJECT
     public:
-        InterfaceSyncedCheckbox(const MainWindow*, std::weak_ptr<InterfaceControllerClient>, std::string, QWidget* = nullptr);
+        InterfaceSyncedCheckbox(std::weak_ptr<InterfaceControllerClient>, std::string, QWidget* = nullptr);
     protected:
         std::string identity;
 
         std::weak_ptr<InterfaceControllerClient> ctrl;
         void updateProps(const InterfaceDeclaration&);
     protected slots:
-        void updateDeclaration(std::weak_ptr<InterfaceDeclarations>);
-        void updateValue(std::weak_ptr<InterfaceSettings>);
+        void updateDeclaration();
+        void updateValue();
 
         void notifyChangedValue(int state);
 

--- a/libs/interface/include/InterfaceSyncedDropdown.h
+++ b/libs/interface/include/InterfaceSyncedDropdown.h
@@ -13,7 +13,7 @@ namespace rtt::Interface {
     class InterfaceSyncedDropdown: public QComboBox {
         Q_OBJECT
     public:
-        InterfaceSyncedDropdown(const MainWindow*, std::weak_ptr<InterfaceControllerClient>, std::string, QWidget* = nullptr);
+        InterfaceSyncedDropdown(std::weak_ptr<InterfaceControllerClient>, std::string, QWidget* = nullptr);
     protected:
         std::string identity;
 
@@ -21,8 +21,8 @@ namespace rtt::Interface {
         void updateProps(const InterfaceDeclaration&);
     private slots:
         void didChangeValue(const QString&);
-        void updateDeclaration(std::weak_ptr<InterfaceDeclarations>);
-        void updateValue(std::weak_ptr<InterfaceSettings>);
+        void updateDeclaration();
+        void updateValue();
 
     };
 }

--- a/libs/interface/include/InterfaceSyncedRadio.h
+++ b/libs/interface/include/InterfaceSyncedRadio.h
@@ -14,7 +14,7 @@ namespace rtt::Interface {
     class InterfaceSyncedRadio: public QButtonGroup {
         Q_OBJECT
     public:
-        InterfaceSyncedRadio(const MainWindow*, std::weak_ptr<InterfaceControllerClient>, std::string, QWidget* = nullptr);
+        InterfaceSyncedRadio(std::weak_ptr<InterfaceControllerClient>, std::string, QWidget* = nullptr);
     private:
         std::string identity;
         int dpi;
@@ -23,8 +23,8 @@ namespace rtt::Interface {
 
         void updateProps(const InterfaceDeclaration&);
     protected slots:
-        void updateDeclaration(std::weak_ptr<InterfaceDeclarations>);
-        void updateValue(std::weak_ptr<InterfaceSettings>);
+        void updateDeclaration();
+        void updateValue();
 
         void notifyChangedValue(int id, bool enabled);
 

--- a/libs/interface/include/InterfaceSyncedSlider.h
+++ b/libs/interface/include/InterfaceSyncedSlider.h
@@ -13,7 +13,7 @@ namespace rtt::Interface {
     class InterfaceSyncedSlider: public QSlider {
         Q_OBJECT
     public:
-        InterfaceSyncedSlider(const MainWindow*, std::weak_ptr<InterfaceControllerClient>, std::string, QWidget* = nullptr);
+        InterfaceSyncedSlider(std::weak_ptr<InterfaceControllerClient>, std::string, QWidget* = nullptr);
     private:
         std::string identity;
         int dpi;
@@ -22,8 +22,8 @@ namespace rtt::Interface {
 
         void updateProps(const InterfaceDeclaration&);
     protected slots:
-        void updateDeclaration(std::weak_ptr<InterfaceDeclarations>);
-        void updateValue(std::weak_ptr<InterfaceSettings>);
+        void updateDeclaration();
+        void updateValue();
 
         void notifyChangedValue(int value);
 

--- a/libs/interface/include/InterfaceSyncedText.h
+++ b/libs/interface/include/InterfaceSyncedText.h
@@ -13,14 +13,14 @@ namespace rtt::Interface {
     class InterfaceSyncedText: public QLineEdit {
         Q_OBJECT
     public:
-        InterfaceSyncedText(const MainWindow*, std::weak_ptr<InterfaceControllerClient>, std::string, QWidget* = nullptr);
+        InterfaceSyncedText(std::weak_ptr<InterfaceControllerClient>, std::string, QWidget* = nullptr);
     protected:
         std::string identity;
 
         std::weak_ptr<InterfaceControllerClient> ctrl;
     protected slots:
-        void updateDeclaration(std::weak_ptr<InterfaceDeclarations>);
-        void updateValue(std::weak_ptr<InterfaceSettings>);
+        void updateDeclaration();
+        void updateValue();
 
         void notifyChangedValue(const QString& text);
 

--- a/libs/interface/include/InterfaceWidgetDebugDisplay.h
+++ b/libs/interface/include/InterfaceWidgetDebugDisplay.h
@@ -12,7 +12,7 @@
 namespace rtt::Interface {
     class InterfaceWidgetDebugDisplay: public QWidget {
     public:
-        InterfaceWidgetDebugDisplay(const MainWindow*, std::weak_ptr<InterfaceControllerClient>, QWidget* = nullptr);
+        InterfaceWidgetDebugDisplay(std::weak_ptr<InterfaceControllerClient>, QWidget* = nullptr);
     private:
         std::weak_ptr<InterfaceControllerClient> ctrl;
         const MainWindow* window;

--- a/libs/interface/include/InterfaceWidgetDebugDisplay.h
+++ b/libs/interface/include/InterfaceWidgetDebugDisplay.h
@@ -17,7 +17,7 @@ namespace rtt::Interface {
         std::weak_ptr<InterfaceControllerClient> ctrl;
         const MainWindow* window;
 
-        void fullRefresh(const std::vector<std::tuple<std::string, InterfaceValue>>&);
+        void fullRefresh(const std::vector<std::string>&);
     private slots:
         void valuesDidChange();
     };

--- a/libs/interface/include/InterfaceWidgetRobotDisplay.h
+++ b/libs/interface/include/InterfaceWidgetRobotDisplay.h
@@ -5,12 +5,12 @@
 #ifndef RTT_INTERFACEWIDGETROBOTDISPLAY_H
 #define RTT_INTERFACEWIDGETROBOTDISPLAY_H
 
-#include <QWidget>
+#include <QFrame>
 #include <QLabel>
 #include <proto/WorldRobot.pb.h>
 
 namespace rtt::Interface {
-    class InterfaceWidgetRobotDisplay: public QWidget {
+    class InterfaceWidgetRobotDisplay: public QFrame {
         Q_OBJECT
     public:
         InterfaceWidgetRobotDisplay(QWidget* parent = nullptr);

--- a/libs/interface/include/InterfaceWidgetRobotOverview.h
+++ b/libs/interface/include/InterfaceWidgetRobotOverview.h
@@ -17,7 +17,7 @@ namespace rtt::Interface {
     class InterfaceWidgetRobotOverview: public QWidget {
         Q_OBJECT
     public:
-        InterfaceWidgetRobotOverview(const MainWindow*, std::weak_ptr<InterfaceControllerClient>, QWidget* = nullptr);
+        InterfaceWidgetRobotOverview(std::weak_ptr<InterfaceControllerClient>, QWidget* = nullptr);
 
     private:
         std::weak_ptr<InterfaceControllerClient> controller;

--- a/libs/interface/src/InterfaceControllerClient.cpp
+++ b/libs/interface/src/InterfaceControllerClient.cpp
@@ -30,4 +30,9 @@ namespace rtt::Interface {
     void InterfaceControllerClient::field_state_callback(const proto::State& state) {
         this->fieldState->setState(state);
     }
+    void InterfaceControllerClient::stop() {
+        this->field_subscriber.reset(); // Prevent ugly crashes on exit
+
+        InterfaceController::stop();
+    }
 }

--- a/libs/interface/src/InterfaceFieldScene.cpp
+++ b/libs/interface/src/InterfaceFieldScene.cpp
@@ -9,7 +9,7 @@
 
 InterfaceFieldScene::InterfaceFieldScene(std::weak_ptr<InterfaceFieldStateStore> state, QObject* parent): QGraphicsScene(parent), state(state), ball(new InterfaceBallItem()) {
     this->timer = new QTimer(this);
-
+// TODO: Centralize timer
     this->addItem(this->ball);
 
     QObject::connect(timer, &QTimer::timeout, this, &InterfaceFieldScene::triggerUpdate);

--- a/libs/interface/src/InterfaceRobotItem.cpp
+++ b/libs/interface/src/InterfaceRobotItem.cpp
@@ -8,19 +8,19 @@
 void InterfaceRobotItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) {
     painter->save();
     painter->setRenderHint(QPainter::RenderHint::Antialiasing);
-    auto cPen = painter->pen();
-    auto brush = painter->brush();
     if (!isYellow) {
-        cPen.setColor(Qt::blue);
-        brush.setColor(Qt::blue);
+        painter->setPen(Qt::blue);
+        painter->setBrush(Qt::blue);
     } else {
-        cPen.setColor(Qt::yellow);
-        brush.setColor(Qt::yellow);
+        painter->setPen(Qt::yellow);
+        painter->setBrush(Qt::yellow);
     }
 
-    painter->setBrush(brush);
-    painter->setPen(cPen);
     painter->drawEllipse(QPoint{20, 20}, 20, 20);
+
+    painter->setPen(QPen(Qt::red, 3));
+    painter->setBrush(Qt::red);
+    painter->drawLine(20, 20, 40, 20);
     painter->restore();
 }
 
@@ -57,6 +57,11 @@ void InterfaceRobotItem::triggerUpdate(const proto::State& state) {
 
         double x = this->scene()->views()[0]->viewport()->width()/2 + (scale * us->pos().x() * 1000) - 20;
         double y = this->scene()->views()[0]->viewport()->height()/2 + (scale * us->pos().y() * 1000) - 20;
+
+        this->setTransformOriginPoint(QPoint(20 ,20));
+
+        this->setRotation((us->angle()/M_PI) * 180);
+        this->setScale((20 * scale * 4)/20);
 
         this->setPos(x, y);
 

--- a/libs/interface/src/InterfaceRobotItem.cpp
+++ b/libs/interface/src/InterfaceRobotItem.cpp
@@ -5,6 +5,8 @@
 #include "InterfaceRobotItem.h"
 #include <QGraphicsView>
 
+#include <math.h>
+
 void InterfaceRobotItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) {
     painter->save();
     painter->setRenderHint(QPainter::RenderHint::Antialiasing);

--- a/libs/interface/src/InterfaceSyncedCheckableButton.cpp
+++ b/libs/interface/src/InterfaceSyncedCheckableButton.cpp
@@ -6,8 +6,8 @@
 
 namespace rtt::Interface {
 
-    InterfaceSyncedCheckableButton::InterfaceSyncedCheckableButton(std::weak_ptr<InterfaceControllerClient> ctrl, std::string ident, QWidget* parent): QPushButton(parent), ctrl(ctrl), identity(ident) {
-        QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedCheckableButton::updateValue);
+    InterfaceSyncedCheckableButton::InterfaceSyncedCheckableButton(std::weak_ptr<InterfaceControllerClient> ctrl, std::string ident, QWidget* parent): QPushButton(parent), ctrl(std::move(ctrl)), identity(ident) {
+        QObject::connect(this->ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedCheckableButton::updateValue);
         QObject::connect(this, &QPushButton::toggled, this, &InterfaceSyncedCheckableButton::didCheck);
 
         this->setCheckable(true);
@@ -30,7 +30,7 @@ namespace rtt::Interface {
     void InterfaceSyncedCheckableButton::didCheck(bool checked) {
         if(auto ctrl = this->ctrl.lock()) {
             if (auto vals = ctrl->getValues().lock()) {
-                vals->setSetting(this->identity, true);
+                vals->setSetting(this->identity, checked);
             }
         }
     }

--- a/libs/interface/src/InterfaceSyncedCheckableButton.cpp
+++ b/libs/interface/src/InterfaceSyncedCheckableButton.cpp
@@ -6,8 +6,8 @@
 
 namespace rtt::Interface {
 
-    InterfaceSyncedCheckableButton::InterfaceSyncedCheckableButton(const MainWindow *window, std::weak_ptr<InterfaceControllerClient> ctrl, std::string ident, QWidget* parent): QPushButton(parent), ctrl(ctrl), identity(ident) {
-        QObject::connect(window, &MainWindow::valuesChanged, this, &InterfaceSyncedCheckableButton::updateValue);
+    InterfaceSyncedCheckableButton::InterfaceSyncedCheckableButton(std::weak_ptr<InterfaceControllerClient> ctrl, std::string ident, QWidget* parent): QPushButton(parent), ctrl(ctrl), identity(ident) {
+        QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedCheckableButton::updateValue);
         QObject::connect(this, &QPushButton::toggled, this, &InterfaceSyncedCheckableButton::didCheck);
 
         this->setCheckable(true);
@@ -15,8 +15,10 @@ namespace rtt::Interface {
         this->setStyleSheet("QPushButton:checked { background-color: green; border: none;}");
     }
 
-    void InterfaceSyncedCheckableButton::updateValue(std::weak_ptr<InterfaceSettings> valptr) {
-        if (auto vals = valptr.lock()) {
+    void InterfaceSyncedCheckableButton::updateValue() {
+        auto cptr = ctrl.lock();
+
+        if (auto vals = cptr.get()->getValues().lock()) {
             if(vals->getSetting(this->identity) == InterfaceValue(true)) {
                 this->setChecked(true);
             } else {

--- a/libs/interface/src/InterfaceSyncedCheckbox.cpp
+++ b/libs/interface/src/InterfaceSyncedCheckbox.cpp
@@ -9,14 +9,11 @@
 #include "roboteam_interface_utils/InterfaceDeclaration.h"
 
 namespace rtt::Interface {
-    InterfaceSyncedCheckbox::InterfaceSyncedCheckbox(std::weak_ptr<InterfaceControllerClient> ctrl, std::string ident, QWidget *parent): QCheckBox(parent), identity(ident) {
-        QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedCheckbox::updateDeclaration);
-        QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedCheckbox::updateValue);
+    InterfaceSyncedCheckbox::InterfaceSyncedCheckbox(std::weak_ptr<InterfaceControllerClient> ctrl, std::string ident, QWidget *parent): ctrl(std::move(ctrl)), QCheckBox(parent), identity(ident) {
+        QObject::connect(this->ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedCheckbox::updateDeclaration);
+        QObject::connect(this->ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedCheckbox::updateValue);
 
         QObject::connect(this, &InterfaceSyncedCheckbox::stateChanged, this, &InterfaceSyncedCheckbox::notifyChangedValue);
-
-        this->ctrl = ctrl;
-
     }
 
     void InterfaceSyncedCheckbox::updateProps(const InterfaceDeclaration& decl) {

--- a/libs/interface/src/InterfaceSyncedDropdown.cpp
+++ b/libs/interface/src/InterfaceSyncedDropdown.cpp
@@ -6,8 +6,8 @@
 
 namespace rtt::Interface {
     InterfaceSyncedDropdown::InterfaceSyncedDropdown(std::weak_ptr<InterfaceControllerClient> ctrlptr, std::string ident, QWidget* parent): QComboBox(parent), identity(ident), ctrl(ctrlptr) {
-        QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedDropdown::updateDeclaration);
-        QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedDropdown::updateValue);
+        QObject::connect(this->ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedDropdown::updateDeclaration);
+        QObject::connect(this->ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedDropdown::updateValue);
 
         QObject::connect(this, &InterfaceSyncedDropdown::currentTextChanged, this, &InterfaceSyncedDropdown::didChangeValue);
     }
@@ -23,9 +23,7 @@ namespace rtt::Interface {
     }
 
     void InterfaceSyncedDropdown::updateProps(const InterfaceDeclaration& decl) {
-        for (int i = 0; i < this->count(); i++) {
-            this->removeItem(i);
-        }
+        this->clear();
 
         if (!decl.isMutable) this->setEnabled(false);
 
@@ -46,7 +44,20 @@ namespace rtt::Interface {
 
         if (!allDecls) return;
 
-        auto self = allDecls.get()->getDeclaration(this->identity);
+        std::vector<std::string> current_options;
+
+        for (int i = 0; i < this->count(); i++) {
+            current_options.push_back(this->itemText(i).toStdString());
+        }
+
+        auto us = allDecls->getDeclaration(this->identity);
+        if (!us) return;
+
+        if (current_options == std::get<InterfaceDropdown>(us.value().options).options) {
+            return;
+        }
+
+        auto self = allDecls->getDeclaration(this->identity);
         if (!self.has_value()) return;
 
         this->updateProps(self.value());

--- a/libs/interface/src/InterfaceSyncedRadio.cpp
+++ b/libs/interface/src/InterfaceSyncedRadio.cpp
@@ -5,15 +5,13 @@
 #include "InterfaceSyncedRadio.h"
 
 namespace rtt::Interface {
-InterfaceSyncedRadio::InterfaceSyncedRadio(std::weak_ptr<InterfaceControllerClient> ctrlptr, std::string ident, QWidget *parent): QButtonGroup(parent), identity(ident) {
-    QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedRadio::updateDeclaration);
-    QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedRadio::updateValue);
+InterfaceSyncedRadio::InterfaceSyncedRadio(std::weak_ptr<InterfaceControllerClient> ctrlptr, std::string ident, QWidget *parent): ctrl(std::move(ctrlptr)), QButtonGroup(parent), identity(ident) {
+    QObject::connect(this->ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedRadio::updateDeclaration);
+    QObject::connect(this->ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedRadio::updateValue);
 
     QObject::connect(this, &InterfaceSyncedRadio::idToggled, this, &InterfaceSyncedRadio::notifyChangedValue);
 
     this->setExclusive(true);
-
-    this->ctrl = ctrlptr;
 }
 
 void InterfaceSyncedRadio::updateProps(const InterfaceDeclaration &decl) {

--- a/libs/interface/src/InterfaceSyncedRadio.cpp
+++ b/libs/interface/src/InterfaceSyncedRadio.cpp
@@ -5,9 +5,9 @@
 #include "InterfaceSyncedRadio.h"
 
 namespace rtt::Interface {
-InterfaceSyncedRadio::InterfaceSyncedRadio(const MainWindow * window, std::weak_ptr<InterfaceControllerClient> ctrlptr, std::string ident, QWidget *parent): QButtonGroup(parent), identity(ident) {
-    QObject::connect(window, &MainWindow::declarationsChanged, this, &InterfaceSyncedRadio::updateDeclaration);
-    QObject::connect(window, &MainWindow::valuesChanged, this, &InterfaceSyncedRadio::updateValue);
+InterfaceSyncedRadio::InterfaceSyncedRadio(std::weak_ptr<InterfaceControllerClient> ctrlptr, std::string ident, QWidget *parent): QButtonGroup(parent), identity(ident) {
+    QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedRadio::updateDeclaration);
+    QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedRadio::updateValue);
 
     QObject::connect(this, &InterfaceSyncedRadio::idToggled, this, &InterfaceSyncedRadio::notifyChangedValue);
 
@@ -39,8 +39,8 @@ void InterfaceSyncedRadio::updateProps(const InterfaceDeclaration &decl) {
 
 
 }
-void InterfaceSyncedRadio::updateDeclaration(std::weak_ptr<InterfaceDeclarations> declptr) {
-    auto alldecl = declptr.lock();
+void InterfaceSyncedRadio::updateDeclaration() {
+    auto alldecl = ctrl.lock()->getDeclarations().lock();
     if (!alldecl) return;
 
     auto decl = alldecl.get()->getDeclaration(this->identity);
@@ -50,10 +50,11 @@ void InterfaceSyncedRadio::updateDeclaration(std::weak_ptr<InterfaceDeclarations
     this->updateProps(decl.value());
 }
 
-void InterfaceSyncedRadio::updateValue(std::weak_ptr<InterfaceSettings> settings) {
-    auto values = settings.lock();
+void InterfaceSyncedRadio::updateValue() {
+    auto lockCtrl = ctrl.lock();
+    auto values = lockCtrl.get()->getValues().lock();
     if (!values) return;
-    this->updateDeclaration(ctrl.lock()->getDeclarations());
+    this->updateDeclaration();
     auto newVal = values.get()->getSetting(this->identity);
     if (!newVal.has_value()) return;
 

--- a/libs/interface/src/InterfaceSyncedSlider.cpp
+++ b/libs/interface/src/InterfaceSyncedSlider.cpp
@@ -5,16 +5,14 @@
 #include "InterfaceSyncedSlider.h"
 
 namespace rtt::Interface {
-    InterfaceSyncedSlider::InterfaceSyncedSlider(std::weak_ptr<InterfaceControllerClient> ctrl, std::string ident, QWidget *parent): QSlider(parent), identity(ident){
-        QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedSlider::updateDeclaration);
-        QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedSlider::updateValue);
+    InterfaceSyncedSlider::InterfaceSyncedSlider(std::weak_ptr<InterfaceControllerClient> ctrl, std::string ident, QWidget *parent): ctrl(std::move(ctrl)), QSlider(parent), identity(ident){
+        QObject::connect(this->ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedSlider::updateDeclaration);
+        QObject::connect(this->ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedSlider::updateValue);
 
         QObject::connect(this, &InterfaceSyncedSlider::valueChanged, this, &InterfaceSyncedSlider::notifyChangedValue);
 
         this->setTracking(false);
         this->setOrientation(Qt::Horizontal);
-
-        this->ctrl = ctrl;
     }
 
     void InterfaceSyncedSlider::updateValue() {

--- a/libs/interface/src/InterfaceSyncedText.cpp
+++ b/libs/interface/src/InterfaceSyncedText.cpp
@@ -5,17 +5,17 @@
 #include "InterfaceSyncedText.h"
 
 namespace rtt::Interface {
-    InterfaceSyncedText::InterfaceSyncedText(const MainWindow *window, std::weak_ptr<InterfaceControllerClient> ctrlptr, std::string ident, QWidget *parent): QLineEdit(parent), identity(ident) {
-        QObject::connect(window, &MainWindow::declarationsChanged, this, &InterfaceSyncedText::updateDeclaration);
-        QObject::connect(window, &MainWindow::valuesChanged, this, &InterfaceSyncedText::updateValue);
+    InterfaceSyncedText::InterfaceSyncedText(std::weak_ptr<InterfaceControllerClient> ctrlptr, std::string ident, QWidget *parent): QLineEdit(parent), identity(ident) {
+        QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedText::updateDeclaration);
+        QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedText::updateValue);
 
         QObject::connect(this, &InterfaceSyncedText::textChanged, this, &InterfaceSyncedText::notifyChangedValue);
 
         this->ctrl = ctrlptr;
     }
 
-    void InterfaceSyncedText::updateValue(std::weak_ptr<InterfaceSettings> settings) {
-        auto vals = settings.lock();
+    void InterfaceSyncedText::updateValue() {
+        auto vals = this->ctrl.lock().get()->getValues().lock();
 
         if (!vals) return;
 
@@ -31,7 +31,7 @@ namespace rtt::Interface {
         }
     }
 
-    void InterfaceSyncedText::updateDeclaration(std::weak_ptr<InterfaceDeclarations> declPtr) {
+    void InterfaceSyncedText::updateDeclaration() {
         return;
     }
 

--- a/libs/interface/src/InterfaceSyncedText.cpp
+++ b/libs/interface/src/InterfaceSyncedText.cpp
@@ -5,13 +5,12 @@
 #include "InterfaceSyncedText.h"
 
 namespace rtt::Interface {
-    InterfaceSyncedText::InterfaceSyncedText(std::weak_ptr<InterfaceControllerClient> ctrlptr, std::string ident, QWidget *parent): QLineEdit(parent), identity(ident) {
-        QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedText::updateDeclaration);
-        QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedText::updateValue);
+    InterfaceSyncedText::InterfaceSyncedText(std::weak_ptr<InterfaceControllerClient> ctrlptr, std::string ident, QWidget *parent): ctrl(std::move(ctrlptr)), QLineEdit(parent), identity(ident) {
+        QObject::connect(this->ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedText::updateDeclaration);
+        QObject::connect(this->ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceSyncedText::updateValue);
 
         QObject::connect(this, &InterfaceSyncedText::textChanged, this, &InterfaceSyncedText::notifyChangedValue);
 
-        this->ctrl = ctrlptr;
     }
 
     void InterfaceSyncedText::updateValue() {

--- a/libs/interface/src/InterfaceWidgetDebugDisplay.cpp
+++ b/libs/interface/src/InterfaceWidgetDebugDisplay.cpp
@@ -15,9 +15,9 @@
 
 namespace rtt::Interface {
 
-    InterfaceWidgetDebugDisplay::InterfaceWidgetDebugDisplay(const MainWindow *window, std::weak_ptr<InterfaceControllerClient> ctrl, QWidget *parent): QWidget(parent), ctrl(std::move(ctrl)), window(window) {
-        QObject::connect(window, &MainWindow::valuesChanged, this, &InterfaceWidgetDebugDisplay::valuesDidChange);
-        QObject::connect(window, &MainWindow::declarationsChanged, this, &InterfaceWidgetDebugDisplay::valuesDidChange);
+    InterfaceWidgetDebugDisplay::InterfaceWidgetDebugDisplay(std::weak_ptr<InterfaceControllerClient> ctrl, QWidget *parent): QWidget(parent), ctrl(std::move(ctrl)), window(window) {
+        QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceWidgetDebugDisplay::valuesDidChange);
+        QObject::connect(ctrl.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceWidgetDebugDisplay::valuesDidChange);
         this->setLayout(new QVBoxLayout);
 
     }
@@ -52,15 +52,15 @@ namespace rtt::Interface {
             auto this_decl = decls->getDeclaration(key);
             this->layout()->addWidget(new QLabel(QString::fromStdString(this_decl->path)));
             if (const auto* slider = std::get_if<Interface::InterfaceSlider>(&this_decl->options)) {
-                this->layout()->addWidget(new InterfaceSyncedSlider(window, this->ctrl, key));
+                this->layout()->addWidget(new InterfaceSyncedSlider(this->ctrl, key));
             } else if (const auto* checkbox = std::get_if<InterfaceCheckbox>(&this_decl->options)) {
-                this->layout()->addWidget(new InterfaceSyncedCheckbox(window, this->ctrl, key));
+                this->layout()->addWidget(new InterfaceSyncedCheckbox(this->ctrl, key));
             } else if (const auto* dropdown = std::get_if<InterfaceDropdown>(&this_decl->options)) {
-                this->layout()->addWidget(new InterfaceSyncedDropdown(window, this->ctrl, key));
+                this->layout()->addWidget(new InterfaceSyncedDropdown(this->ctrl, key));
             } else if (const auto* radio = std::get_if<InterfaceRadio>(&this_decl->options)) {
                 auto tmpLayout = new QHBoxLayout;
                 auto tmpWidget = new QWidget;
-                auto radioButtons = new InterfaceSyncedRadio(window, this->ctrl, key);
+                auto radioButtons = new InterfaceSyncedRadio(this->ctrl, key);
                 for (auto button : radioButtons->buttons()) {
                     tmpLayout->addWidget(button);
                 }
@@ -69,7 +69,7 @@ namespace rtt::Interface {
                 tmpWidget->setLayout(tmpLayout);
                 this->layout()->addWidget(tmpWidget);
             } else if (const auto* text = std::get_if<InterfaceText>(&this_decl->options)) {
-                this->layout()->addWidget(new InterfaceSyncedText(window, this->ctrl, key));
+                this->layout()->addWidget(new InterfaceSyncedText(this->ctrl, key));
             } else {
                 throw std::logic_error{"Variant was in an invalid state when serialising InterfaceDeclaration to JSON!"};
             }

--- a/libs/interface/src/InterfaceWidgetRobotDisplay.cpp
+++ b/libs/interface/src/InterfaceWidgetRobotDisplay.cpp
@@ -4,18 +4,36 @@
 
 #include "InterfaceWidgetRobotDisplay.h"
 
+#include <QPainter>
+#include <QPainterPath>
 #include <QVBoxLayout>
 
 namespace rtt::Interface {
-    InterfaceWidgetRobotDisplay::InterfaceWidgetRobotDisplay(QWidget *parent): QWidget(parent), data(new QLabel) {
+    InterfaceWidgetRobotDisplay::InterfaceWidgetRobotDisplay(QWidget *parent): QFrame(parent), data(new QLabel) {
         data->setText("null\nnull\nnull");
 
         QVBoxLayout* layout = new QVBoxLayout;
         QLabel* placeholder = new QLabel;
+        QPixmap pixmap(80, 80);
+        pixmap.fill(Qt::transparent);
+        QPainter painter(&pixmap);
+        this->setFrameStyle(QFrame::StyledPanel | QFrame::Raised);
+        this->setLineWidth(2);
+        this->setMidLineWidth(0);
+//        this->setFrameShadow(Shadow::Raised);
 
-        placeholder->setWordWrap(true);
+        QBrush brush({112,39,195});
+        painter.setBrush(brush);
+
+        painter.drawEllipse({40, 40}, 40, 40);
+
+        painter.drawText(40, 40, "T");
+
+        placeholder->setPixmap(pixmap);
+
+//        placeholder->setWordWrap(true);
         placeholder->setAlignment(Qt::AlignCenter);
-        placeholder->setText("a\nb\nc\n");
+//        placeholder->setText("a\nb\nc\n");
 
         data->setWordWrap(true);
         data->setAlignment(Qt::AlignCenter);
@@ -28,5 +46,6 @@ namespace rtt::Interface {
 
     void InterfaceWidgetRobotDisplay::refreshData(const proto::WorldRobot &robot) {
         data->setText(QString::fromStdString(std::to_string(robot.id()) + "\n" + "(" + std::to_string(robot.pos().x()) + "," + std::to_string(robot.pos().x()) + ")" + "\n" + "W: " + std::to_string(robot.w())));
+        data->setFixedWidth(150);
     }
 }

--- a/libs/interface/src/InterfaceWidgetRobotOverview.cpp
+++ b/libs/interface/src/InterfaceWidgetRobotOverview.cpp
@@ -7,8 +7,8 @@
 
 #include <utility>
 namespace rtt::Interface {
-    InterfaceWidgetRobotOverview::InterfaceWidgetRobotOverview(const MainWindow* window, std::weak_ptr<InterfaceControllerClient> ctrl, QWidget *parent): QWidget(parent), controller(std::move(ctrl)) {
-        QObject::connect(window, &MainWindow::valuesChanged, this, &InterfaceWidgetRobotOverview::doUpdate);
+    InterfaceWidgetRobotOverview::InterfaceWidgetRobotOverview(std::weak_ptr<InterfaceControllerClient> ctrl, QWidget *parent): QWidget(parent), controller(std::move(ctrl)) {
+        QObject::connect(this->controller.lock().get(), &InterfaceControllerClient::refresh_trigger, this, &InterfaceWidgetRobotOverview::doUpdate);
         this->setLayout(new QHBoxLayout);
         this->layout()->setAlignment(Qt::AlignmentFlag::AlignCenter);
     }
@@ -24,7 +24,7 @@ namespace rtt::Interface {
 
             auto state = fieldState->getState();
 
-            auto robots = vals->getSetting("IS_YELLOW").value() == InterfaceValue(true) ? state.ball_camera_world().yellow() : state.ball_camera_world().blue();
+            auto robots = vals->getSetting("IS_YELLOW").value() == InterfaceValue(true) ? state.last_seen_world().yellow() : state.last_seen_world().blue();
 
             if (this->displays.size() != robots.size()) {
                 while (auto item = this->layout()->takeAt(0)) {

--- a/libs/interface_utils/include/roboteam_interface_utils/InterfaceController.h
+++ b/libs/interface_utils/include/roboteam_interface_utils/InterfaceController.h
@@ -88,7 +88,7 @@ namespace rtt::Interface  {
             this->loopThread = std::move(t1);
         }
 
-        void stop() {
+        virtual void stop() {
             this->should_run.store(false);
             this->loopThread.join();
         }

--- a/libs/interface_utils/include/roboteam_interface_utils/InterfaceDeclarations.h
+++ b/libs/interface_utils/include/roboteam_interface_utils/InterfaceDeclarations.h
@@ -21,8 +21,6 @@ class InterfaceDeclarations {
 
        mutable std::mutex mtx;
 
-       std::atomic_bool did_change;
-
    public:
        ~InterfaceDeclarations() = default;
 
@@ -46,12 +44,11 @@ class InterfaceDeclarations {
 
        std::map<std::string, InterfaceDeclaration> getDeclarations() const noexcept;
        std::optional<InterfaceDeclaration> getDeclaration(std::string) const noexcept;
+       std::vector<std::string> getWithSuffix(const std::string&) const noexcept;
 
        void handleData(const proto::UiOptionDeclarations&) noexcept;
 
        proto::UiOptionDeclarations toProto() const noexcept;
-
-       bool getDidChange();
 };
 
 }


### PR DESCRIPTION
Synchronize interface updates (single update signal) and lay out basic components of the interface.

Fix simple issues (such as interface crashing on exit due to the field subscriber)